### PR TITLE
scuapi: fix indentation for python 3.11 and older

### DIFF
--- a/scuapi/scuapi.py
+++ b/scuapi/scuapi.py
@@ -106,8 +106,7 @@ class API:
         search_results = document.json()["data"]
         output_dict = {}
         for result in search_results:
-            result["url"] = f"{
-                self._url}/titles/{result['id']}-{result['slug']}"
+            result["url"] = f"{self._url}/titles/{result['id']}-{result['slug']}"
             output_dict[result["name"]] = result
 
         return output_dict  # [result for result in search_results]


### PR DESCRIPTION
python 3.12 handles string indentation a bit differently as i can deduce, so this little fix make your API work with versions older than that.