### PR TITLE
Fix search() endpoint: /api/search → /it/search (404 on current mirrors)

### DIFF
--- a/scuapi/scuapi.py
+++ b/scuapi/scuapi.py
@@ -171,9 +171,9 @@ class API:
         ```
         """
 
-        headers = {"user-agent": self.user_agent}
+        headers = {"user-agent": self.user_agent, "accept": "application/json"}
         query_formatted = query.replace(" ", "%20")
-        url = f"{self._url.geturl()}/api/search?q={query_formatted}"
+        url = f"{self._url.geturl()}/it/search?q={query_formatted}"
 
         try:
             # Ottenere i risultati della ricerca


### PR DESCRIPTION
## Problem

`search()` currently fails on every live StreamingCommunity mirror because the legacy `/api/search` route no longer exists. A live test against `streamingcommunityz.bargains` returns:

```
GET /api/search?q=John%20Wick  →  404 Not Found
```

This makes `search()` always raise `InvalidJSON` (the 404 HTML body fails `response.json()`). `preview()` and `load()` are unaffected and keep working as-is.

## Fix

The current frontend serves the search at `/it/search` and returns JSON when the request asks for it via `Accept: application/json` (Laravel content negotiation). The response shape is unchanged — same top-level `data: [...]` with the same item fields (`id`, `slug`, `name`, `type`, ...) — so the downstream parsing in `search()` keeps working without further changes.

Two-line change:

```diff
-        headers = {"user-agent": self.user_agent}
+        headers = {"user-agent": self.user_agent, "accept": "application/json"}
         query_formatted = query.replace(" ", "%20")
-        url = f"{self._url.geturl()}/api/search?q={query_formatted}"
+        url = f"{self._url.geturl()}/it/search?q={query_formatted}"
```

## Verification

Against `streamingcommunityz.bargains` on 2026-05-11, all public methods continue to work end-to-end:

| Method | Before | After |
|---|---|---|
| `search('John Wick')` | ❌ `InvalidJSON` (404) | ✅ 60 results |
| `preview('6-john-wick')` | ✅ | ✅ (unchanged) |
| `load('6-john-wick')` (movie) | ✅ | ✅ (unchanged) |
| `load('305-the-boys')` (tv) | ✅ | ✅ 38 episodes, 5 seasons |
| `search → preview` pipeline | ❌ | ✅ slugs match |

## Scope

Intentionally minimal — only the `search()` method touched. No new dependencies, no API surface change, no behavior change for callers.